### PR TITLE
Correct boolean shell property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ $RECYCLE.BIN/
 *.msi
 *.msm
 *.msp
+/.vs

--- a/source/WindowsAPICodePack/Core/PropertySystem/PropVariant.cs
+++ b/source/WindowsAPICodePack/Core/PropertySystem/PropVariant.cs
@@ -636,7 +636,7 @@ namespace MS.WindowsAPICodePack.Internal
                     case VarEnum.VT_R8:
                         return _double;
                     case VarEnum.VT_BOOL:
-                        return _int32 == -1;
+                        return _short == -1;
                     case VarEnum.VT_ERROR:
                         return _long;
                     case VarEnum.VT_CY:


### PR DESCRIPTION
The windows api code pack incorrectly uses int32 instead of short in the PropVariant resulting in boolean shell properties returning false for true values.  

If you want to demo that this is the case, I found the simplest thing to do was to right click an mp3 and add "Yes" for "Part of a compilation".

![image](https://user-images.githubusercontent.com/11292998/91451215-1affa280-e875-11ea-8bb9-93666164ac54.png)

Then compare one with Yes and one without.

`
private bool? TrackIsPartOfCompilation(string trackPath)
{
        var mp3 = ShellObject.FromParsingName(trackPath);
        var isPartOfCompilationProperty = mp3.Properties.System.Music.IsCompilation;
        return isPartOfCompilationProperty.Value;
}
`